### PR TITLE
Fix: ignore www prefix when sorting tabs by URL

### DIFF
--- a/build/chrome-extension/tab-sorter.js
+++ b/build/chrome-extension/tab-sorter.js
@@ -388,8 +388,13 @@ function faviconSort(tabs, comparisonFunction, reverse) {
 
 // Comparison functions
 
+// Compare tabs by domain name (without www prefix)
+// This ensures consistent sorting regardless of www. prefix in URLs
+// See: https://github.com/etienneschalk/tab-sorter-firefox/issues/20
 function comparisonByUrl(tabA, tabB) {
-  return tabA.url.localeCompare(tabB.url);
+  const domainA = extractDomain(tabA.url);
+  const domainB = extractDomain(tabB.url);
+  return domainA.localeCompare(domainB);
 }
 
 function comparisonByMru(tabA, tabB) {

--- a/build/firefox-extension/tab-sorter.js
+++ b/build/firefox-extension/tab-sorter.js
@@ -388,8 +388,13 @@ function faviconSort(tabs, comparisonFunction, reverse) {
 
 // Comparison functions
 
+// Compare tabs by domain name (without www prefix)
+// This ensures consistent sorting regardless of www. prefix in URLs
+// See: https://github.com/etienneschalk/tab-sorter-firefox/issues/20
 function comparisonByUrl(tabA, tabB) {
-  return tabA.url.localeCompare(tabB.url);
+  const domainA = extractDomain(tabA.url);
+  const domainB = extractDomain(tabB.url);
+  return domainA.localeCompare(domainB);
 }
 
 function comparisonByMru(tabA, tabB) {

--- a/template-extension/tab-sorter.js
+++ b/template-extension/tab-sorter.js
@@ -388,8 +388,13 @@ function faviconSort(tabs, comparisonFunction, reverse) {
 
 // Comparison functions
 
+// Compare tabs by domain name (without www prefix)
+// This ensures consistent sorting regardless of www. prefix in URLs
+// See: https://github.com/etienneschalk/tab-sorter-firefox/issues/20
 function comparisonByUrl(tabA, tabB) {
-  return tabA.url.localeCompare(tabB.url);
+  const domainA = extractDomain(tabA.url);
+  const domainB = extractDomain(tabB.url);
+  return domainA.localeCompare(domainB);
 }
 
 function comparisonByMru(tabA, tabB) {


### PR DESCRIPTION
## Summary

Fixed issue #20 - www prefix is now ignored when sorting tabs by URL.

## Changes

Modified `comparisonByUrl()` to use `extractDomain()` which removes www. prefix

This ensures consistent sorting regardless of www prefix in URLs

 ## Example
 
Before: `github.com | amazon.com | google.com` (because 'w' > 'g')
After: `amazon.com | github.com | google.com` (sorted by domain name)
 
Closes #20