### PR TITLE
Add option to close duplicate tabs when sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.8] - 2026-05-19
+
+### Added
+- **Close duplicate tabs** - Optional preference to close duplicate tabs when sorting (keeps the leftmost tab). Matches normalized URLs (ignores hash, query string, `www`, case) and the same issue-tracker resource when the URL shape differs. Closes [#17](https://github.com/etienneschalk/tab-sorter-firefox/issues/17).
+
 ## [0.7] - 2025-09-16
 
 ### Added

--- a/build/chrome-extension/_locales/en/messages.json
+++ b/build/chrome-extension/_locales/en/messages.json
@@ -79,6 +79,10 @@
     "message": "Sort tabs in all windows",
     "description": "Sorting tabs also in other windows"
   },
+  "ui_click_checkbox_sort_tabs_close_duplicates": {
+    "message": "Close duplicate tabs",
+    "description": "Close tabs with the same URL when using a sort action"
+  },
   "ui_click_checkbox_sort_tabs_auto_best_effort": {
     "message": "Sort tabs automatically (best effort).",
     "description": "Sort tabs automatically (best effort)."

--- a/build/chrome-extension/_locales/fr/messages.json
+++ b/build/chrome-extension/_locales/fr/messages.json
@@ -75,6 +75,10 @@
     "message": "Trier dans toutes les fenêtres",
     "description": "Sorting tabs also in other windows"
   },
+  "ui_click_checkbox_sort_tabs_close_duplicates": {
+    "message": "Fermer les onglets en double lors du tri",
+    "description": "Fermer les onglets ayant la même URL lors d'une action de tri"
+  },
   "ui_click_checkbox_sort_tabs_auto_best_effort": {
     "message": "Trier automatiquement les onglets (meilleur effort)",
     "description": "Sort tabs automatically (best effort)."

--- a/build/chrome-extension/manifest.json
+++ b/build/chrome-extension/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "author": "Etienne Schalk",
-  "version": "0.7",
+  "version": "0.8",
   "action": {
     "default_title": "Tab Sorter",
     "default_popup": "tab-sorter.html"

--- a/build/chrome-extension/popup-tab-sorter.js
+++ b/build/chrome-extension/popup-tab-sorter.js
@@ -14,6 +14,7 @@ function initializeUserInterface(initialState) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands,
@@ -23,6 +24,7 @@ function initializeUserInterface(initialState) {
   console.log(logPrefix + "isReverse", isReverse);
   console.log(logPrefix + "isAllWindows", isAllWindows);
   console.log(logPrefix + "isAutoOnNewTab", isAutoOnNewTab);
+  console.log(logPrefix + "isCloseDuplicateTabs", isCloseDuplicateTabs);
   console.log(logPrefix + "defaultSortMethod", defaultSortMethod);
   console.log(logPrefix + "availableSortMethods", availableSortMethods);
 
@@ -41,6 +43,7 @@ function initializeUserInterface(initialState) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands: allCommands
@@ -61,6 +64,8 @@ function initializeUserInterface(initialState) {
 const CHECKBOX_REVERSE = "ui_click_checkbox_sort_tabs_reverse";
 const CHECKBOX_ALL_WINDOWS = "ui_click_checkbox_sort_tabs_all_windows";
 const CHECKBOX_AUTO_ON_NEW_TAB = "ui_click_checkbox_sort_tabs_auto_best_effort";
+const CHECKBOX_CLOSE_DUPLICATES =
+  "ui_click_checkbox_sort_tabs_close_duplicates";
 const SELECT_DEFAULT_SORT_METHOD =
   "ui_change_select_sort_select_tabs_default_sort_method";
 
@@ -136,6 +141,7 @@ function renderPopup(params) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands,
@@ -168,6 +174,7 @@ function renderPopup(params) {
             <h3> ${translate("preferences_general")}</h3>
             ${renderCheckbox(CHECKBOX_REVERSE, isReverse)}
             ${renderCheckbox(CHECKBOX_ALL_WINDOWS, isAllWindows)}
+            ${renderCheckbox(CHECKBOX_CLOSE_DUPLICATES, isCloseDuplicateTabs)}
             <br> 
             <h3> ${translate("preferences_auto")}</h3>
             ${renderCheckbox(CHECKBOX_AUTO_ON_NEW_TAB, isAutoOnNewTab)}

--- a/build/chrome-extension/tab-sorter.js
+++ b/build/chrome-extension/tab-sorter.js
@@ -27,6 +27,9 @@ const STORAGE_DEFAULT_VALUE_AUTO_SORT_ON_NEW_TAB = false;
 const STORAGE_KEY_DEFAULT_SORT_METHOD =
   "TAB_SORTER_STORAGE_KEY_DEFAULT_SORT_METHOD";
 const STORAGE_DEFAULT_VALUE_DEFAULT_SORT_METHOD = AVAILABLE_SORT_METHODS[1];
+const STORAGE_KEY_CLOSE_DUPLICATE_TABS =
+  "TAB_SORTER_STORAGE_KEY_CLOSE_DUPLICATE_TABS";
+const STORAGE_DEFAULT_VALUE_CLOSE_DUPLICATE_TABS = false;
 
 const CACHE_KEY_ALL_COMMANDS = "CACHE_KEY_ALL_COMMANDS";
 
@@ -62,6 +65,14 @@ async function getDefaultSortMethodAsync() {
     STORAGE_DEFAULT_VALUE_DEFAULT_SORT_METHOD
   );
 }
+
+async function getCloseDuplicateTabsAsync() {
+  return await retrieveFromStorage(
+    STORAGE_KEY_CLOSE_DUPLICATE_TABS,
+    STORAGE_DEFAULT_VALUE_CLOSE_DUPLICATE_TABS
+  );
+}
+
 async function getAllCommandsFromManifest() {
   const allCommands = await chrome.commands.getAll();
   CACHED_STATE[CACHE_KEY_ALL_COMMANDS] = allCommands;
@@ -87,6 +98,7 @@ async function resetCacheAsync() {
   await getAllWindowsAsync();
   await getAutoOnNewTabAsync();
   await getDefaultSortMethodAsync();
+  await getCloseDuplicateTabsAsync();
   await getAllCommandsFromManifest();
 }
 
@@ -118,6 +130,10 @@ function getDefaultSortMethodCached() {
   return value;
 }
 
+function getCloseDuplicateTabsCached() {
+  return CACHED_STATE[STORAGE_KEY_CLOSE_DUPLICATE_TABS];
+}
+
 function setReverse(choice) {
   persistInStorage(STORAGE_KEY_REVERSE, choice);
 }
@@ -132,6 +148,10 @@ function setAutoSortBestEffort(choice) {
 
 function setDefaultSortMethod(choice) {
   persistInStorage(STORAGE_KEY_DEFAULT_SORT_METHOD, choice);
+}
+
+function setCloseDuplicateTabs(choice) {
+  persistInStorage(STORAGE_KEY_CLOSE_DUPLICATE_TABS, choice);
 }
 
 async function retrieveFromStorage(key, default_value) {
@@ -181,6 +201,7 @@ function addEventListeners() {
           isAllWindows: CACHED_STATE[STORAGE_KEY_SORT_ALL_WINDOWS],
           isAutoOnNewTab: CACHED_STATE[STORAGE_KEY_AUTO_SORT_BEST_EFFORT],
           defaultSortMethod: CACHED_STATE[STORAGE_KEY_DEFAULT_SORT_METHOD],
+          isCloseDuplicateTabs: CACHED_STATE[STORAGE_KEY_CLOSE_DUPLICATE_TABS],
           availableSortMethods: AVAILABLE_SORT_METHODS,
           allCommands: CACHED_STATE[CACHE_KEY_ALL_COMMANDS],
         };
@@ -351,6 +372,8 @@ function stateUpdateEventListener(command, value) {
     command === "ui_change_select_sort_select_tabs_default_sort_method"
   ) {
     setDefaultSortMethod(value);
+  } else if (command === "ui_click_checkbox_sort_tabs_close_duplicates") {
+    setCloseDuplicateTabs(value);
   }
 }
 
@@ -421,101 +444,167 @@ function sortTabs(sortingType, shuffle) {
   console.debug(`${log_prefix} with '${sortingType}'`);
 
   getCurrentWindowTabs(function (tabs) {
-    console.debug("Callback of getCurrentWindowTabs 1");
-    let notPinnedTabs = tabs.filter((tab) => !tab.pinned); // Not taking in account pinned tabs
-    let comparisonFunction;
-    let customSort = undefined;
-
-    console.debug(notPinnedTabs);
-
-    switch (sortingType) {
-      case "sort_tabs_url":
-        comparisonFunction = comparisonByUrl;
-        break;
-      case "sort_tabs_mru":
-        // TODO Not working on chromium!
-        // WIP, See https://groups.google.com/a/chromium.org/g/extensions-reviews/c/iokG6nMuLio
-        // Addition 2025-09-16: This is now working on chromium!
-        // https://developer.chrome.com/docs/extensions/reference/api/tabs
-        // lastAccessed property is now available in Chrome 121+
-        comparisonFunction = comparisonByMru;
-        break;
-      case "sort_tabs_title":
-        comparisonFunction = comparisonByTitle;
-        break;
-      case "sort_tabs_favicon_and_title":
-        comparisonFunction = comparisonByTitle;
-        customSort = faviconSort;
-        break;
-      default:
-        comparisonFunction = comparisonByUrl;
-    }
-
-    console.debug(
-      "Callback of getCurrentWindowTabs 2",
-      `${comparisonFunction.name}, ${customSort ? customSort.name : ""}`
-    );
-
-    if (customSort) {
-      notPinnedTabs = customSort(
-        notPinnedTabs,
-        comparisonFunction,
-        getReverseCached()
-      );
+    if (getCloseDuplicateTabsCached()) {
+      closeDuplicateTabs(tabs, (tabIdsToClose) => {
+        const tabsToSort =
+          tabIdsToClose.length === 0
+            ? tabs
+            : tabs.filter((t) => !tabIdsToClose.includes(t.id));
+        performSort(tabsToSort, sortingType, doShuffle, log_prefix);
+      });
     } else {
-      if (getReverseCached()) {
-        notPinnedTabs.sort((tabB, tabA) => comparisonFunction(tabA, tabB));
-        console.debug(`${log_prefix} Reverse sorting`);
-      } else {
-        notPinnedTabs.sort((tabA, tabB) => comparisonFunction(tabA, tabB));
-      }
-    }
-
-    console.debug("Callback of getCurrentWindowTabs 3");
-
-    let newIds = notPinnedTabs.map((tab) => tab.id); // Get an array of the tabs ids
-
-    console.debug(`Callback of getCurrentWindowTabs 4 - Before Shuffle`);
-
-    if (doShuffle) {
-      console.debug(`${log_prefix} Shuffling tabs`);
-      let i = newIds.length;
-      let j, temp;
-      if (i != 0) {
-        while (--i) {
-          j = Math.floor(Math.random() * (i + 1));
-          temp = newIds[j];
-          newIds[j] = newIds[i];
-          newIds[i] = temp;
-        }
-      }
-    }
-
-    let numberOfPinnedTabs = tabs.length - notPinnedTabs.length;
-
-    if (DEBUG) {
-      performance.mark("begin");
-    }
-
-    console.debug(
-      `Callback of getCurrentWindowTabs 5 - Before actual tab move`
-    );
-
-    // The index seems to be useless in this case of moving all the tabs
-    chrome.tabs.move(newIds, {
-      index: numberOfPinnedTabs,
-    });
-
-    if (DEBUG) {
-      performance.mark("end");
-      performance.measure("Tab reorganizing time", "begin", "end");
-      console.table(
-        performance.getEntriesByType("measure").map((e) => [e.name, e.duration])
-      );
-      performance.clearMarks();
-      performance.clearMeasures();
+      performSort(tabs, sortingType, doShuffle, log_prefix);
     }
   });
+}
+
+// Normalized URL: no hash, no query string, no www, lowercase, no trailing slash.
+function getUrlMatchKey(url) {
+  try {
+    const p = new URL(url);
+    const host = p.hostname.replace(/^www\./i, "").toLowerCase();
+    const path = p.pathname.length > 1 ? p.pathname.replace(/\/$/, "") : p.pathname;
+    return `${p.protocol}//${host}${path}`.toLowerCase();
+  } catch {
+    return url.toLowerCase();
+  }
+}
+
+// Closes duplicate unpinned tabs, keeping the leftmost occurrence.
+// Mirrors DTC: URL key first, then title key (when enabled and tab is loaded).
+// Invokes callback with the list of closed tab ids (empty if none).
+function closeDuplicateTabs(tabs, callback) {
+  const log_prefix = `${TAB_SORTER_PREFIX} (closeDuplicateTabs):`;
+  const seenKeys = new Set();
+  const tabIdsToClose = [];
+
+  tabs.forEach((tab) => {
+    if (tab.pinned) {
+      return;
+    }
+    const urlKey = getUrlMatchKey(tab.url);
+    const titleKey = tab.status === "complete" && tab.title
+      ? `title:${tab.title}`
+      : null;
+
+    if (seenKeys.has(urlKey) || (titleKey && seenKeys.has(titleKey))) {
+      tabIdsToClose.push(tab.id);
+    } else {
+      seenKeys.add(urlKey);
+      if (titleKey) seenKeys.add(titleKey);
+    }
+  });
+
+  if (tabIdsToClose.length === 0) {
+    callback(tabIdsToClose);
+    return;
+  }
+
+  console.debug(
+    `${log_prefix} Closing ${tabIdsToClose.length} duplicate tab(s)`
+  );
+  chrome.tabs.remove(tabIdsToClose, () => {
+    if (chrome.runtime.lastError) {
+      console.error(`${log_prefix}`, chrome.runtime.lastError);
+    }
+    callback(tabIdsToClose);
+  });
+}
+
+function performSort(tabs, sortingType, doShuffle, log_prefix) {
+  let notPinnedTabs = tabs.filter((tab) => !tab.pinned); // Not taking in account pinned tabs
+  let comparisonFunction;
+  let customSort = undefined;
+
+  console.debug(notPinnedTabs);
+
+  switch (sortingType) {
+    case "sort_tabs_url":
+      comparisonFunction = comparisonByUrl;
+      break;
+    case "sort_tabs_mru":
+      // TODO Not working on chromium!
+      // WIP, See https://groups.google.com/a/chromium.org/g/extensions-reviews/c/iokG6nMuLio
+      // Addition 2025-09-16: This is now working on chromium!
+      // https://developer.chrome.com/docs/extensions/reference/api/tabs
+      // lastAccessed property is now available in Chrome 121+
+      comparisonFunction = comparisonByMru;
+      break;
+    case "sort_tabs_title":
+      comparisonFunction = comparisonByTitle;
+      break;
+    case "sort_tabs_favicon_and_title":
+      comparisonFunction = comparisonByTitle;
+      customSort = faviconSort;
+      break;
+    default:
+      comparisonFunction = comparisonByUrl;
+  }
+
+  console.debug(
+    "Callback of getCurrentWindowTabs 2",
+    `${comparisonFunction.name}, ${customSort ? customSort.name : ""}`
+  );
+
+  if (customSort) {
+    notPinnedTabs = customSort(
+      notPinnedTabs,
+      comparisonFunction,
+      getReverseCached()
+    );
+  } else {
+    if (getReverseCached()) {
+      notPinnedTabs.sort((tabB, tabA) => comparisonFunction(tabA, tabB));
+      console.debug(`${log_prefix} Reverse sorting`);
+    } else {
+      notPinnedTabs.sort((tabA, tabB) => comparisonFunction(tabA, tabB));
+    }
+  }
+
+  console.debug("Callback of getCurrentWindowTabs 3");
+
+  let newIds = notPinnedTabs.map((tab) => tab.id); // Get an array of the tabs ids
+
+  console.debug(`Callback of getCurrentWindowTabs 4 - Before Shuffle`);
+
+  if (doShuffle) {
+    console.debug(`${log_prefix} Shuffling tabs`);
+    let i = newIds.length;
+    let j, temp;
+    if (i != 0) {
+      while (--i) {
+        j = Math.floor(Math.random() * (i + 1));
+        temp = newIds[j];
+        newIds[j] = newIds[i];
+        newIds[i] = temp;
+      }
+    }
+  }
+
+  let numberOfPinnedTabs = tabs.length - notPinnedTabs.length;
+
+  if (DEBUG) {
+    performance.mark("begin");
+  }
+
+  console.debug(
+    `Callback of getCurrentWindowTabs 5 - Before actual tab move`
+  );
+
+  // The index seems to be useless in this case of moving all the tabs
+  chrome.tabs.move(newIds, {
+    index: numberOfPinnedTabs,
+  });
+
+  if (DEBUG) {
+    performance.mark("end");
+    performance.measure("Tab reorganizing time", "begin", "end");
+    console.table(
+      performance.getEntriesByType("measure").map((e) => [e.name, e.duration])
+    );
+    performance.clearMarks();
+    performance.clearMeasures();
+  }
 }
 
 // Helpers

--- a/build/firefox-extension/_locales/en/messages.json
+++ b/build/firefox-extension/_locales/en/messages.json
@@ -79,6 +79,10 @@
     "message": "Sort tabs in all windows",
     "description": "Sorting tabs also in other windows"
   },
+  "ui_click_checkbox_sort_tabs_close_duplicates": {
+    "message": "Close duplicate tabs",
+    "description": "Close tabs with the same URL when using a sort action"
+  },
   "ui_click_checkbox_sort_tabs_auto_best_effort": {
     "message": "Sort tabs automatically (best effort).",
     "description": "Sort tabs automatically (best effort)."

--- a/build/firefox-extension/_locales/fr/messages.json
+++ b/build/firefox-extension/_locales/fr/messages.json
@@ -75,6 +75,10 @@
     "message": "Trier dans toutes les fenêtres",
     "description": "Sorting tabs also in other windows"
   },
+  "ui_click_checkbox_sort_tabs_close_duplicates": {
+    "message": "Fermer les onglets en double lors du tri",
+    "description": "Fermer les onglets ayant la même URL lors d'une action de tri"
+  },
   "ui_click_checkbox_sort_tabs_auto_best_effort": {
     "message": "Trier automatiquement les onglets (meilleur effort)",
     "description": "Sort tabs automatically (best effort)."

--- a/build/firefox-extension/manifest.json
+++ b/build/firefox-extension/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "author": "Etienne Schalk",
-  "version": "0.7",
+  "version": "0.8",
   "action": {
     "default_title": "Tab Sorter",
     "default_popup": "tab-sorter.html"

--- a/build/firefox-extension/popup-tab-sorter.js
+++ b/build/firefox-extension/popup-tab-sorter.js
@@ -14,6 +14,7 @@ function initializeUserInterface(initialState) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands,
@@ -23,6 +24,7 @@ function initializeUserInterface(initialState) {
   console.log(logPrefix + "isReverse", isReverse);
   console.log(logPrefix + "isAllWindows", isAllWindows);
   console.log(logPrefix + "isAutoOnNewTab", isAutoOnNewTab);
+  console.log(logPrefix + "isCloseDuplicateTabs", isCloseDuplicateTabs);
   console.log(logPrefix + "defaultSortMethod", defaultSortMethod);
   console.log(logPrefix + "availableSortMethods", availableSortMethods);
 
@@ -41,6 +43,7 @@ function initializeUserInterface(initialState) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands: allCommands
@@ -61,6 +64,8 @@ function initializeUserInterface(initialState) {
 const CHECKBOX_REVERSE = "ui_click_checkbox_sort_tabs_reverse";
 const CHECKBOX_ALL_WINDOWS = "ui_click_checkbox_sort_tabs_all_windows";
 const CHECKBOX_AUTO_ON_NEW_TAB = "ui_click_checkbox_sort_tabs_auto_best_effort";
+const CHECKBOX_CLOSE_DUPLICATES =
+  "ui_click_checkbox_sort_tabs_close_duplicates";
 const SELECT_DEFAULT_SORT_METHOD =
   "ui_change_select_sort_select_tabs_default_sort_method";
 
@@ -136,6 +141,7 @@ function renderPopup(params) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands,
@@ -168,6 +174,7 @@ function renderPopup(params) {
             <h3> ${translate("preferences_general")}</h3>
             ${renderCheckbox(CHECKBOX_REVERSE, isReverse)}
             ${renderCheckbox(CHECKBOX_ALL_WINDOWS, isAllWindows)}
+            ${renderCheckbox(CHECKBOX_CLOSE_DUPLICATES, isCloseDuplicateTabs)}
             <br> 
             <h3> ${translate("preferences_auto")}</h3>
             ${renderCheckbox(CHECKBOX_AUTO_ON_NEW_TAB, isAutoOnNewTab)}

--- a/build/firefox-extension/tab-sorter.js
+++ b/build/firefox-extension/tab-sorter.js
@@ -27,6 +27,9 @@ const STORAGE_DEFAULT_VALUE_AUTO_SORT_ON_NEW_TAB = false;
 const STORAGE_KEY_DEFAULT_SORT_METHOD =
   "TAB_SORTER_STORAGE_KEY_DEFAULT_SORT_METHOD";
 const STORAGE_DEFAULT_VALUE_DEFAULT_SORT_METHOD = AVAILABLE_SORT_METHODS[1];
+const STORAGE_KEY_CLOSE_DUPLICATE_TABS =
+  "TAB_SORTER_STORAGE_KEY_CLOSE_DUPLICATE_TABS";
+const STORAGE_DEFAULT_VALUE_CLOSE_DUPLICATE_TABS = false;
 
 const CACHE_KEY_ALL_COMMANDS = "CACHE_KEY_ALL_COMMANDS";
 
@@ -62,6 +65,14 @@ async function getDefaultSortMethodAsync() {
     STORAGE_DEFAULT_VALUE_DEFAULT_SORT_METHOD
   );
 }
+
+async function getCloseDuplicateTabsAsync() {
+  return await retrieveFromStorage(
+    STORAGE_KEY_CLOSE_DUPLICATE_TABS,
+    STORAGE_DEFAULT_VALUE_CLOSE_DUPLICATE_TABS
+  );
+}
+
 async function getAllCommandsFromManifest() {
   const allCommands = await chrome.commands.getAll();
   CACHED_STATE[CACHE_KEY_ALL_COMMANDS] = allCommands;
@@ -87,6 +98,7 @@ async function resetCacheAsync() {
   await getAllWindowsAsync();
   await getAutoOnNewTabAsync();
   await getDefaultSortMethodAsync();
+  await getCloseDuplicateTabsAsync();
   await getAllCommandsFromManifest();
 }
 
@@ -118,6 +130,10 @@ function getDefaultSortMethodCached() {
   return value;
 }
 
+function getCloseDuplicateTabsCached() {
+  return CACHED_STATE[STORAGE_KEY_CLOSE_DUPLICATE_TABS];
+}
+
 function setReverse(choice) {
   persistInStorage(STORAGE_KEY_REVERSE, choice);
 }
@@ -132,6 +148,10 @@ function setAutoSortBestEffort(choice) {
 
 function setDefaultSortMethod(choice) {
   persistInStorage(STORAGE_KEY_DEFAULT_SORT_METHOD, choice);
+}
+
+function setCloseDuplicateTabs(choice) {
+  persistInStorage(STORAGE_KEY_CLOSE_DUPLICATE_TABS, choice);
 }
 
 async function retrieveFromStorage(key, default_value) {
@@ -181,6 +201,7 @@ function addEventListeners() {
           isAllWindows: CACHED_STATE[STORAGE_KEY_SORT_ALL_WINDOWS],
           isAutoOnNewTab: CACHED_STATE[STORAGE_KEY_AUTO_SORT_BEST_EFFORT],
           defaultSortMethod: CACHED_STATE[STORAGE_KEY_DEFAULT_SORT_METHOD],
+          isCloseDuplicateTabs: CACHED_STATE[STORAGE_KEY_CLOSE_DUPLICATE_TABS],
           availableSortMethods: AVAILABLE_SORT_METHODS,
           allCommands: CACHED_STATE[CACHE_KEY_ALL_COMMANDS],
         };
@@ -351,6 +372,8 @@ function stateUpdateEventListener(command, value) {
     command === "ui_change_select_sort_select_tabs_default_sort_method"
   ) {
     setDefaultSortMethod(value);
+  } else if (command === "ui_click_checkbox_sort_tabs_close_duplicates") {
+    setCloseDuplicateTabs(value);
   }
 }
 
@@ -421,101 +444,167 @@ function sortTabs(sortingType, shuffle) {
   console.debug(`${log_prefix} with '${sortingType}'`);
 
   getCurrentWindowTabs(function (tabs) {
-    console.debug("Callback of getCurrentWindowTabs 1");
-    let notPinnedTabs = tabs.filter((tab) => !tab.pinned); // Not taking in account pinned tabs
-    let comparisonFunction;
-    let customSort = undefined;
-
-    console.debug(notPinnedTabs);
-
-    switch (sortingType) {
-      case "sort_tabs_url":
-        comparisonFunction = comparisonByUrl;
-        break;
-      case "sort_tabs_mru":
-        // TODO Not working on chromium!
-        // WIP, See https://groups.google.com/a/chromium.org/g/extensions-reviews/c/iokG6nMuLio
-        // Addition 2025-09-16: This is now working on chromium!
-        // https://developer.chrome.com/docs/extensions/reference/api/tabs
-        // lastAccessed property is now available in Chrome 121+
-        comparisonFunction = comparisonByMru;
-        break;
-      case "sort_tabs_title":
-        comparisonFunction = comparisonByTitle;
-        break;
-      case "sort_tabs_favicon_and_title":
-        comparisonFunction = comparisonByTitle;
-        customSort = faviconSort;
-        break;
-      default:
-        comparisonFunction = comparisonByUrl;
-    }
-
-    console.debug(
-      "Callback of getCurrentWindowTabs 2",
-      `${comparisonFunction.name}, ${customSort ? customSort.name : ""}`
-    );
-
-    if (customSort) {
-      notPinnedTabs = customSort(
-        notPinnedTabs,
-        comparisonFunction,
-        getReverseCached()
-      );
+    if (getCloseDuplicateTabsCached()) {
+      closeDuplicateTabs(tabs, (tabIdsToClose) => {
+        const tabsToSort =
+          tabIdsToClose.length === 0
+            ? tabs
+            : tabs.filter((t) => !tabIdsToClose.includes(t.id));
+        performSort(tabsToSort, sortingType, doShuffle, log_prefix);
+      });
     } else {
-      if (getReverseCached()) {
-        notPinnedTabs.sort((tabB, tabA) => comparisonFunction(tabA, tabB));
-        console.debug(`${log_prefix} Reverse sorting`);
-      } else {
-        notPinnedTabs.sort((tabA, tabB) => comparisonFunction(tabA, tabB));
-      }
-    }
-
-    console.debug("Callback of getCurrentWindowTabs 3");
-
-    let newIds = notPinnedTabs.map((tab) => tab.id); // Get an array of the tabs ids
-
-    console.debug(`Callback of getCurrentWindowTabs 4 - Before Shuffle`);
-
-    if (doShuffle) {
-      console.debug(`${log_prefix} Shuffling tabs`);
-      let i = newIds.length;
-      let j, temp;
-      if (i != 0) {
-        while (--i) {
-          j = Math.floor(Math.random() * (i + 1));
-          temp = newIds[j];
-          newIds[j] = newIds[i];
-          newIds[i] = temp;
-        }
-      }
-    }
-
-    let numberOfPinnedTabs = tabs.length - notPinnedTabs.length;
-
-    if (DEBUG) {
-      performance.mark("begin");
-    }
-
-    console.debug(
-      `Callback of getCurrentWindowTabs 5 - Before actual tab move`
-    );
-
-    // The index seems to be useless in this case of moving all the tabs
-    chrome.tabs.move(newIds, {
-      index: numberOfPinnedTabs,
-    });
-
-    if (DEBUG) {
-      performance.mark("end");
-      performance.measure("Tab reorganizing time", "begin", "end");
-      console.table(
-        performance.getEntriesByType("measure").map((e) => [e.name, e.duration])
-      );
-      performance.clearMarks();
-      performance.clearMeasures();
+      performSort(tabs, sortingType, doShuffle, log_prefix);
     }
   });
+}
+
+// Normalized URL: no hash, no query string, no www, lowercase, no trailing slash.
+function getUrlMatchKey(url) {
+  try {
+    const p = new URL(url);
+    const host = p.hostname.replace(/^www\./i, "").toLowerCase();
+    const path = p.pathname.length > 1 ? p.pathname.replace(/\/$/, "") : p.pathname;
+    return `${p.protocol}//${host}${path}`.toLowerCase();
+  } catch {
+    return url.toLowerCase();
+  }
+}
+
+// Closes duplicate unpinned tabs, keeping the leftmost occurrence.
+// Mirrors DTC: URL key first, then title key (when enabled and tab is loaded).
+// Invokes callback with the list of closed tab ids (empty if none).
+function closeDuplicateTabs(tabs, callback) {
+  const log_prefix = `${TAB_SORTER_PREFIX} (closeDuplicateTabs):`;
+  const seenKeys = new Set();
+  const tabIdsToClose = [];
+
+  tabs.forEach((tab) => {
+    if (tab.pinned) {
+      return;
+    }
+    const urlKey = getUrlMatchKey(tab.url);
+    const titleKey = tab.status === "complete" && tab.title
+      ? `title:${tab.title}`
+      : null;
+
+    if (seenKeys.has(urlKey) || (titleKey && seenKeys.has(titleKey))) {
+      tabIdsToClose.push(tab.id);
+    } else {
+      seenKeys.add(urlKey);
+      if (titleKey) seenKeys.add(titleKey);
+    }
+  });
+
+  if (tabIdsToClose.length === 0) {
+    callback(tabIdsToClose);
+    return;
+  }
+
+  console.debug(
+    `${log_prefix} Closing ${tabIdsToClose.length} duplicate tab(s)`
+  );
+  chrome.tabs.remove(tabIdsToClose, () => {
+    if (chrome.runtime.lastError) {
+      console.error(`${log_prefix}`, chrome.runtime.lastError);
+    }
+    callback(tabIdsToClose);
+  });
+}
+
+function performSort(tabs, sortingType, doShuffle, log_prefix) {
+  let notPinnedTabs = tabs.filter((tab) => !tab.pinned); // Not taking in account pinned tabs
+  let comparisonFunction;
+  let customSort = undefined;
+
+  console.debug(notPinnedTabs);
+
+  switch (sortingType) {
+    case "sort_tabs_url":
+      comparisonFunction = comparisonByUrl;
+      break;
+    case "sort_tabs_mru":
+      // TODO Not working on chromium!
+      // WIP, See https://groups.google.com/a/chromium.org/g/extensions-reviews/c/iokG6nMuLio
+      // Addition 2025-09-16: This is now working on chromium!
+      // https://developer.chrome.com/docs/extensions/reference/api/tabs
+      // lastAccessed property is now available in Chrome 121+
+      comparisonFunction = comparisonByMru;
+      break;
+    case "sort_tabs_title":
+      comparisonFunction = comparisonByTitle;
+      break;
+    case "sort_tabs_favicon_and_title":
+      comparisonFunction = comparisonByTitle;
+      customSort = faviconSort;
+      break;
+    default:
+      comparisonFunction = comparisonByUrl;
+  }
+
+  console.debug(
+    "Callback of getCurrentWindowTabs 2",
+    `${comparisonFunction.name}, ${customSort ? customSort.name : ""}`
+  );
+
+  if (customSort) {
+    notPinnedTabs = customSort(
+      notPinnedTabs,
+      comparisonFunction,
+      getReverseCached()
+    );
+  } else {
+    if (getReverseCached()) {
+      notPinnedTabs.sort((tabB, tabA) => comparisonFunction(tabA, tabB));
+      console.debug(`${log_prefix} Reverse sorting`);
+    } else {
+      notPinnedTabs.sort((tabA, tabB) => comparisonFunction(tabA, tabB));
+    }
+  }
+
+  console.debug("Callback of getCurrentWindowTabs 3");
+
+  let newIds = notPinnedTabs.map((tab) => tab.id); // Get an array of the tabs ids
+
+  console.debug(`Callback of getCurrentWindowTabs 4 - Before Shuffle`);
+
+  if (doShuffle) {
+    console.debug(`${log_prefix} Shuffling tabs`);
+    let i = newIds.length;
+    let j, temp;
+    if (i != 0) {
+      while (--i) {
+        j = Math.floor(Math.random() * (i + 1));
+        temp = newIds[j];
+        newIds[j] = newIds[i];
+        newIds[i] = temp;
+      }
+    }
+  }
+
+  let numberOfPinnedTabs = tabs.length - notPinnedTabs.length;
+
+  if (DEBUG) {
+    performance.mark("begin");
+  }
+
+  console.debug(
+    `Callback of getCurrentWindowTabs 5 - Before actual tab move`
+  );
+
+  // The index seems to be useless in this case of moving all the tabs
+  chrome.tabs.move(newIds, {
+    index: numberOfPinnedTabs,
+  });
+
+  if (DEBUG) {
+    performance.mark("end");
+    performance.measure("Tab reorganizing time", "begin", "end");
+    console.table(
+      performance.getEntriesByType("measure").map((e) => [e.name, e.duration])
+    );
+    performance.clearMarks();
+    performance.clearMeasures();
+  }
 }
 
 // Helpers

--- a/template-extension/_locales/en/messages.json
+++ b/template-extension/_locales/en/messages.json
@@ -79,6 +79,10 @@
     "message": "Sort tabs in all windows",
     "description": "Sorting tabs also in other windows"
   },
+  "ui_click_checkbox_sort_tabs_close_duplicates": {
+    "message": "Close duplicate tabs",
+    "description": "Close tabs with the same URL when using a sort action"
+  },
   "ui_click_checkbox_sort_tabs_auto_best_effort": {
     "message": "Sort tabs automatically (best effort).",
     "description": "Sort tabs automatically (best effort)."

--- a/template-extension/_locales/fr/messages.json
+++ b/template-extension/_locales/fr/messages.json
@@ -75,6 +75,10 @@
     "message": "Trier dans toutes les fenêtres",
     "description": "Sorting tabs also in other windows"
   },
+  "ui_click_checkbox_sort_tabs_close_duplicates": {
+    "message": "Fermer les onglets en double lors du tri",
+    "description": "Fermer les onglets ayant la même URL lors d'une action de tri"
+  },
   "ui_click_checkbox_sort_tabs_auto_best_effort": {
     "message": "Trier automatiquement les onglets (meilleur effort)",
     "description": "Sort tabs automatically (best effort)."

--- a/template-extension/manifest.json
+++ b/template-extension/manifest.json
@@ -4,7 +4,7 @@
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
   "author": "Etienne Schalk",
-  "version": "0.7",
+  "version": "0.8",
   "action": {
     "default_title": "Tab Sorter",
     "default_popup": "tab-sorter.html"

--- a/template-extension/popup-tab-sorter.js
+++ b/template-extension/popup-tab-sorter.js
@@ -14,6 +14,7 @@ function initializeUserInterface(initialState) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands,
@@ -23,6 +24,7 @@ function initializeUserInterface(initialState) {
   console.log(logPrefix + "isReverse", isReverse);
   console.log(logPrefix + "isAllWindows", isAllWindows);
   console.log(logPrefix + "isAutoOnNewTab", isAutoOnNewTab);
+  console.log(logPrefix + "isCloseDuplicateTabs", isCloseDuplicateTabs);
   console.log(logPrefix + "defaultSortMethod", defaultSortMethod);
   console.log(logPrefix + "availableSortMethods", availableSortMethods);
 
@@ -41,6 +43,7 @@ function initializeUserInterface(initialState) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands: allCommands
@@ -61,6 +64,8 @@ function initializeUserInterface(initialState) {
 const CHECKBOX_REVERSE = "ui_click_checkbox_sort_tabs_reverse";
 const CHECKBOX_ALL_WINDOWS = "ui_click_checkbox_sort_tabs_all_windows";
 const CHECKBOX_AUTO_ON_NEW_TAB = "ui_click_checkbox_sort_tabs_auto_best_effort";
+const CHECKBOX_CLOSE_DUPLICATES =
+  "ui_click_checkbox_sort_tabs_close_duplicates";
 const SELECT_DEFAULT_SORT_METHOD =
   "ui_change_select_sort_select_tabs_default_sort_method";
 
@@ -136,6 +141,7 @@ function renderPopup(params) {
     isReverse,
     isAllWindows,
     isAutoOnNewTab,
+    isCloseDuplicateTabs,
     defaultSortMethod,
     availableSortMethods,
     allCommands,
@@ -168,6 +174,7 @@ function renderPopup(params) {
             <h3> ${translate("preferences_general")}</h3>
             ${renderCheckbox(CHECKBOX_REVERSE, isReverse)}
             ${renderCheckbox(CHECKBOX_ALL_WINDOWS, isAllWindows)}
+            ${renderCheckbox(CHECKBOX_CLOSE_DUPLICATES, isCloseDuplicateTabs)}
             <br> 
             <h3> ${translate("preferences_auto")}</h3>
             ${renderCheckbox(CHECKBOX_AUTO_ON_NEW_TAB, isAutoOnNewTab)}

--- a/template-extension/tab-sorter.js
+++ b/template-extension/tab-sorter.js
@@ -27,6 +27,9 @@ const STORAGE_DEFAULT_VALUE_AUTO_SORT_ON_NEW_TAB = false;
 const STORAGE_KEY_DEFAULT_SORT_METHOD =
   "TAB_SORTER_STORAGE_KEY_DEFAULT_SORT_METHOD";
 const STORAGE_DEFAULT_VALUE_DEFAULT_SORT_METHOD = AVAILABLE_SORT_METHODS[1];
+const STORAGE_KEY_CLOSE_DUPLICATE_TABS =
+  "TAB_SORTER_STORAGE_KEY_CLOSE_DUPLICATE_TABS";
+const STORAGE_DEFAULT_VALUE_CLOSE_DUPLICATE_TABS = false;
 
 const CACHE_KEY_ALL_COMMANDS = "CACHE_KEY_ALL_COMMANDS";
 
@@ -62,6 +65,14 @@ async function getDefaultSortMethodAsync() {
     STORAGE_DEFAULT_VALUE_DEFAULT_SORT_METHOD
   );
 }
+
+async function getCloseDuplicateTabsAsync() {
+  return await retrieveFromStorage(
+    STORAGE_KEY_CLOSE_DUPLICATE_TABS,
+    STORAGE_DEFAULT_VALUE_CLOSE_DUPLICATE_TABS
+  );
+}
+
 async function getAllCommandsFromManifest() {
   const allCommands = await chrome.commands.getAll();
   CACHED_STATE[CACHE_KEY_ALL_COMMANDS] = allCommands;
@@ -87,6 +98,7 @@ async function resetCacheAsync() {
   await getAllWindowsAsync();
   await getAutoOnNewTabAsync();
   await getDefaultSortMethodAsync();
+  await getCloseDuplicateTabsAsync();
   await getAllCommandsFromManifest();
 }
 
@@ -118,6 +130,10 @@ function getDefaultSortMethodCached() {
   return value;
 }
 
+function getCloseDuplicateTabsCached() {
+  return CACHED_STATE[STORAGE_KEY_CLOSE_DUPLICATE_TABS];
+}
+
 function setReverse(choice) {
   persistInStorage(STORAGE_KEY_REVERSE, choice);
 }
@@ -132,6 +148,10 @@ function setAutoSortBestEffort(choice) {
 
 function setDefaultSortMethod(choice) {
   persistInStorage(STORAGE_KEY_DEFAULT_SORT_METHOD, choice);
+}
+
+function setCloseDuplicateTabs(choice) {
+  persistInStorage(STORAGE_KEY_CLOSE_DUPLICATE_TABS, choice);
 }
 
 async function retrieveFromStorage(key, default_value) {
@@ -181,6 +201,7 @@ function addEventListeners() {
           isAllWindows: CACHED_STATE[STORAGE_KEY_SORT_ALL_WINDOWS],
           isAutoOnNewTab: CACHED_STATE[STORAGE_KEY_AUTO_SORT_BEST_EFFORT],
           defaultSortMethod: CACHED_STATE[STORAGE_KEY_DEFAULT_SORT_METHOD],
+          isCloseDuplicateTabs: CACHED_STATE[STORAGE_KEY_CLOSE_DUPLICATE_TABS],
           availableSortMethods: AVAILABLE_SORT_METHODS,
           allCommands: CACHED_STATE[CACHE_KEY_ALL_COMMANDS],
         };
@@ -351,6 +372,8 @@ function stateUpdateEventListener(command, value) {
     command === "ui_change_select_sort_select_tabs_default_sort_method"
   ) {
     setDefaultSortMethod(value);
+  } else if (command === "ui_click_checkbox_sort_tabs_close_duplicates") {
+    setCloseDuplicateTabs(value);
   }
 }
 
@@ -421,101 +444,167 @@ function sortTabs(sortingType, shuffle) {
   console.debug(`${log_prefix} with '${sortingType}'`);
 
   getCurrentWindowTabs(function (tabs) {
-    console.debug("Callback of getCurrentWindowTabs 1");
-    let notPinnedTabs = tabs.filter((tab) => !tab.pinned); // Not taking in account pinned tabs
-    let comparisonFunction;
-    let customSort = undefined;
-
-    console.debug(notPinnedTabs);
-
-    switch (sortingType) {
-      case "sort_tabs_url":
-        comparisonFunction = comparisonByUrl;
-        break;
-      case "sort_tabs_mru":
-        // TODO Not working on chromium!
-        // WIP, See https://groups.google.com/a/chromium.org/g/extensions-reviews/c/iokG6nMuLio
-        // Addition 2025-09-16: This is now working on chromium!
-        // https://developer.chrome.com/docs/extensions/reference/api/tabs
-        // lastAccessed property is now available in Chrome 121+
-        comparisonFunction = comparisonByMru;
-        break;
-      case "sort_tabs_title":
-        comparisonFunction = comparisonByTitle;
-        break;
-      case "sort_tabs_favicon_and_title":
-        comparisonFunction = comparisonByTitle;
-        customSort = faviconSort;
-        break;
-      default:
-        comparisonFunction = comparisonByUrl;
-    }
-
-    console.debug(
-      "Callback of getCurrentWindowTabs 2",
-      `${comparisonFunction.name}, ${customSort ? customSort.name : ""}`
-    );
-
-    if (customSort) {
-      notPinnedTabs = customSort(
-        notPinnedTabs,
-        comparisonFunction,
-        getReverseCached()
-      );
+    if (getCloseDuplicateTabsCached()) {
+      closeDuplicateTabs(tabs, (tabIdsToClose) => {
+        const tabsToSort =
+          tabIdsToClose.length === 0
+            ? tabs
+            : tabs.filter((t) => !tabIdsToClose.includes(t.id));
+        performSort(tabsToSort, sortingType, doShuffle, log_prefix);
+      });
     } else {
-      if (getReverseCached()) {
-        notPinnedTabs.sort((tabB, tabA) => comparisonFunction(tabA, tabB));
-        console.debug(`${log_prefix} Reverse sorting`);
-      } else {
-        notPinnedTabs.sort((tabA, tabB) => comparisonFunction(tabA, tabB));
-      }
-    }
-
-    console.debug("Callback of getCurrentWindowTabs 3");
-
-    let newIds = notPinnedTabs.map((tab) => tab.id); // Get an array of the tabs ids
-
-    console.debug(`Callback of getCurrentWindowTabs 4 - Before Shuffle`);
-
-    if (doShuffle) {
-      console.debug(`${log_prefix} Shuffling tabs`);
-      let i = newIds.length;
-      let j, temp;
-      if (i != 0) {
-        while (--i) {
-          j = Math.floor(Math.random() * (i + 1));
-          temp = newIds[j];
-          newIds[j] = newIds[i];
-          newIds[i] = temp;
-        }
-      }
-    }
-
-    let numberOfPinnedTabs = tabs.length - notPinnedTabs.length;
-
-    if (DEBUG) {
-      performance.mark("begin");
-    }
-
-    console.debug(
-      `Callback of getCurrentWindowTabs 5 - Before actual tab move`
-    );
-
-    // The index seems to be useless in this case of moving all the tabs
-    chrome.tabs.move(newIds, {
-      index: numberOfPinnedTabs,
-    });
-
-    if (DEBUG) {
-      performance.mark("end");
-      performance.measure("Tab reorganizing time", "begin", "end");
-      console.table(
-        performance.getEntriesByType("measure").map((e) => [e.name, e.duration])
-      );
-      performance.clearMarks();
-      performance.clearMeasures();
+      performSort(tabs, sortingType, doShuffle, log_prefix);
     }
   });
+}
+
+// Normalized URL: no hash, no query string, no www, lowercase, no trailing slash.
+function getUrlMatchKey(url) {
+  try {
+    const p = new URL(url);
+    const host = p.hostname.replace(/^www\./i, "").toLowerCase();
+    const path = p.pathname.length > 1 ? p.pathname.replace(/\/$/, "") : p.pathname;
+    return `${p.protocol}//${host}${path}`.toLowerCase();
+  } catch {
+    return url.toLowerCase();
+  }
+}
+
+// Closes duplicate unpinned tabs, keeping the leftmost occurrence.
+// Mirrors DTC: URL key first, then title key (when enabled and tab is loaded).
+// Invokes callback with the list of closed tab ids (empty if none).
+function closeDuplicateTabs(tabs, callback) {
+  const log_prefix = `${TAB_SORTER_PREFIX} (closeDuplicateTabs):`;
+  const seenKeys = new Set();
+  const tabIdsToClose = [];
+
+  tabs.forEach((tab) => {
+    if (tab.pinned) {
+      return;
+    }
+    const urlKey = getUrlMatchKey(tab.url);
+    const titleKey = tab.status === "complete" && tab.title
+      ? `title:${tab.title}`
+      : null;
+
+    if (seenKeys.has(urlKey) || (titleKey && seenKeys.has(titleKey))) {
+      tabIdsToClose.push(tab.id);
+    } else {
+      seenKeys.add(urlKey);
+      if (titleKey) seenKeys.add(titleKey);
+    }
+  });
+
+  if (tabIdsToClose.length === 0) {
+    callback(tabIdsToClose);
+    return;
+  }
+
+  console.debug(
+    `${log_prefix} Closing ${tabIdsToClose.length} duplicate tab(s)`
+  );
+  chrome.tabs.remove(tabIdsToClose, () => {
+    if (chrome.runtime.lastError) {
+      console.error(`${log_prefix}`, chrome.runtime.lastError);
+    }
+    callback(tabIdsToClose);
+  });
+}
+
+function performSort(tabs, sortingType, doShuffle, log_prefix) {
+  let notPinnedTabs = tabs.filter((tab) => !tab.pinned); // Not taking in account pinned tabs
+  let comparisonFunction;
+  let customSort = undefined;
+
+  console.debug(notPinnedTabs);
+
+  switch (sortingType) {
+    case "sort_tabs_url":
+      comparisonFunction = comparisonByUrl;
+      break;
+    case "sort_tabs_mru":
+      // TODO Not working on chromium!
+      // WIP, See https://groups.google.com/a/chromium.org/g/extensions-reviews/c/iokG6nMuLio
+      // Addition 2025-09-16: This is now working on chromium!
+      // https://developer.chrome.com/docs/extensions/reference/api/tabs
+      // lastAccessed property is now available in Chrome 121+
+      comparisonFunction = comparisonByMru;
+      break;
+    case "sort_tabs_title":
+      comparisonFunction = comparisonByTitle;
+      break;
+    case "sort_tabs_favicon_and_title":
+      comparisonFunction = comparisonByTitle;
+      customSort = faviconSort;
+      break;
+    default:
+      comparisonFunction = comparisonByUrl;
+  }
+
+  console.debug(
+    "Callback of getCurrentWindowTabs 2",
+    `${comparisonFunction.name}, ${customSort ? customSort.name : ""}`
+  );
+
+  if (customSort) {
+    notPinnedTabs = customSort(
+      notPinnedTabs,
+      comparisonFunction,
+      getReverseCached()
+    );
+  } else {
+    if (getReverseCached()) {
+      notPinnedTabs.sort((tabB, tabA) => comparisonFunction(tabA, tabB));
+      console.debug(`${log_prefix} Reverse sorting`);
+    } else {
+      notPinnedTabs.sort((tabA, tabB) => comparisonFunction(tabA, tabB));
+    }
+  }
+
+  console.debug("Callback of getCurrentWindowTabs 3");
+
+  let newIds = notPinnedTabs.map((tab) => tab.id); // Get an array of the tabs ids
+
+  console.debug(`Callback of getCurrentWindowTabs 4 - Before Shuffle`);
+
+  if (doShuffle) {
+    console.debug(`${log_prefix} Shuffling tabs`);
+    let i = newIds.length;
+    let j, temp;
+    if (i != 0) {
+      while (--i) {
+        j = Math.floor(Math.random() * (i + 1));
+        temp = newIds[j];
+        newIds[j] = newIds[i];
+        newIds[i] = temp;
+      }
+    }
+  }
+
+  let numberOfPinnedTabs = tabs.length - notPinnedTabs.length;
+
+  if (DEBUG) {
+    performance.mark("begin");
+  }
+
+  console.debug(
+    `Callback of getCurrentWindowTabs 5 - Before actual tab move`
+  );
+
+  // The index seems to be useless in this case of moving all the tabs
+  chrome.tabs.move(newIds, {
+    index: numberOfPinnedTabs,
+  });
+
+  if (DEBUG) {
+    performance.mark("end");
+    performance.measure("Tab reorganizing time", "begin", "end");
+    console.table(
+      performance.getEntriesByType("measure").map((e) => [e.name, e.duration])
+    );
+    performance.clearMarks();
+    performance.clearMeasures();
+  }
 }
 
 // Helpers


### PR DESCRIPTION
## Summary

Adds a checkbox to close duplicate tabs (same URL) when sorting. Keeps the leftmost tab; pinned tabs are not closed.

Closes #17

<img width="762" height="533" alt="image" src="https://github.com/user-attachments/assets/8206ad88-3c8a-46d8-b641-1eacfbc761ed" />

## Test verification

- [x] Enable **Close duplicate tabs when sorting** in the popup
- [x] Open duplicate URLs, sort → extras close, one tab per URL left
- [x] Pinned duplicates are not closed